### PR TITLE
multiple fomains

### DIFF
--- a/deploy/opt/dijon/compose/docker-compose.prod.yaml
+++ b/deploy/opt/dijon/compose/docker-compose.prod.yaml
@@ -16,7 +16,7 @@ services:
       - GUNICORN_CMD_ARGS=--forwarded-allow-ips='*'
     labels:
       - traefik.enable=true
-      - traefik.http.routers.fastapi.rule=Host(`dijon.jrb.lol`)
+      - traefik.http.routers.fastapi.rule=Host(`dijon.jrb.lol`, `dijon-api.bmlt.dev`)
       - traefik.http.routers.fastapi.tls=true
       - traefik.http.routers.fastapi.tls.certresolver=letsencrypt
     env_file:


### PR DESCRIPTION
I think this should do it, according to this https://doc.traefik.io/traefik/https/acme/#domain-definition see https://doc.traefik.io/traefik/https/acme/#configuration-examples

if not maybe this?

```
traefik.http.routers.fastapi.rule=Host(`dijon.jrb.lol`, `dijon-api.bmlt.dev`)
```
